### PR TITLE
docs: track deferred cable system art + sound assets

### DIFF
--- a/docs/art-asset-tracker.md
+++ b/docs/art-asset-tracker.md
@@ -125,6 +125,21 @@ Dedicated animations for ambient states. Currently using existing animations as 
 | A5 | `zzz_particle` | — | 3 | 8x8 | **Low** | Floating Z's above sleeping animals. Procedural position. |
 | A6 | `heart_particle` | — | 3 | 8x8 | **Low** | Floating hearts for content animals near companions. |
 
+### HUM Cable System (Phase 2)
+
+Deferred from the cable system PR. The wiring HUD currently runs with an empty `DanglingTip` glyph and no socket affordance on host sprites.
+
+| # | Asset | Frames | Size | Priority | Description |
+|---|---|---|---|---|---|
+| C1 | `cable_tip_dangling_strip1` | 1 | 10x10 | **High** | Cursor glyph for the picked-up cable end while wiring mode is active. Dotted circle, transparent center, unlit Slate Void. Path: `mods/tcp_base/sprites/infrastructure/cables/cable_tip_dangling_strip1.png`. Referenced by `nodes/hud/dangling_tip.gd`. |
+| C2 | HUM device socket inset | — | 10x10 region | **High** | Bake a 10×10 socket indentation into the existing `hum_device_static_strip1.png` sprite at its connection point. Unlit Slate Void by default; runtime shader lifts it in wiring mode to cue a valid target. |
+| C3 | TUNA dispenser socket inset | — | 10x10 region | **High** | Same treatment for the dispenser sprite. The tuna dispenser currently has no dedicated `_strip1` sprite — if one is authored first (see #TBD), bake the socket into it. Otherwise add the inset to whatever sprite renders for `tcp_base:tuna_dispenser`. |
+| C4 | ARM socket inset | — | 10x10 region | **High** | Same treatment for `arm_idle.png` (or whichever sprite is canonical for the ARM entity). |
+
+Notes:
+- Socket insets must be pixel-aligned to the 10×10 grid so the `cable_tip_dangling` glyph visually registers to the inset when the cursor hovers.
+- Shader-driven wiring-mode highlight is out of scope for the art pass; asset just needs the baked inset.
+
 ### Prototype Gaps (from asset-pipeline.md spec)
 
 Assets listed in the pipeline spec's "Must-Have" list that don't exist yet:

--- a/docs/sound-asset-tracker.md
+++ b/docs/sound-asset-tracker.md
@@ -76,6 +76,17 @@ Sounds listed in the pipeline spec's "Must-Have" list that don't exist yet:
 | S3 | Fabric kneading | `objects/fabric_knead_01.wav` | 1-2 sec | Loop | **Low** | Soft fabric pressing/pulling sound during KNEADING on soft surfaces. |
 | S4 | Ferret dook (excited) | `ferret/ferret_dook_excited_01.wav` | 0.5 sec | One-shot | **Low** | Faster, higher-pitched variant of dook for high-energy moments. |
 
+### HUM Cable System (Phase 2)
+
+Deferred from the cable system PR. Wired into `sound_manager.gd` on `Events.cable_connected` / `Events.cable_disconnected` and HUM brownout signals.
+
+| # | Sound | File | Duration | Type | Priority | Description |
+|---|---|---|---|---|---|---|
+| C1 | Cable pop | `infrastructure/cable_pop_01.wav` | ~0.2 sec | One-shot | **High** | RJ45-clip release — the satisfying plastic "tick-pop" of a network cable latching or unlatching. Plays on `cable_connected` and `cable_disconnected`. Supersedes the older `cable_plug` entry (#13). **Search terms:** "RJ45 click," "ethernet plug," "plastic latch release." |
+| C2 | Cable lift | `infrastructure/cable_lift_01.wav` | ~0.1 sec | One-shot | **High** | Dry 2-3 kHz click on pickup — distinct from cable_pop, shorter and drier. Plays when a cable end is picked up in wiring mode (before the new endpoint is chosen). **Search terms:** "dry click," "short tick," "plastic tap." |
+| C3 | HUM brownout enter | `ambient/hum_brownout_enter_01.wav` | ~0.4 sec | One-shot | **High** | Detune-and-die tone — the ambient hum dropping out of harmonic lock. Played once on HUM reserve crossing the brownout threshold downward. Should feel regretful, not alarming. **Synthesis ref:** sine wave at ~27 Hz's third harmonic (~80 Hz) with pitch detune down 30 cents over the duration, amplitude tail. |
+| C4 | HUM brownout recover | `ambient/hum_brownout_recover_01.wav` | ~0.4 sec | One-shot | **High** | Soft re-engage swell — the ambient hum pulling back into lock. Played once on HUM reserve crossing the brownout threshold upward. Pairs with C3 as the recovery inverse. **Synthesis ref:** reverse of C3's pitch curve, amplitude swell rather than tail. |
+
 ### Social Desire Feature (Ring 1)
 
 | # | Sound | File | Duration | Type | Priority | Description |


### PR DESCRIPTION
## Summary

Docs-only follow-up to the Phase 2 cable system PR (#8). Adds a "HUM Cable System" section to both asset trackers documenting what the cable HUD currently runs without, so future asset passes have a clear brief.

- **Sounds (C1-C4):** cable_pop, cable_lift, hum_brownout_enter, hum_brownout_recover. Notes supersession of the older `cable_plug` entry (#13).
- **Art (C1-C4):** cable_tip_dangling_strip1 glyph + 10×10 socket insets for hum_device, tuna_dispenser, arm sprites.

No code changes. No behavior changes.

## Test plan

- [x] Doc-only; no validate run needed, but ran locally — still 11/11 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)