### PR TITLE
Pixelize CLI: arbitrary images → pixel-art sprites

### DIFF
--- a/script/pixelize
+++ b/script/pixelize
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # Converts an arbitrary image into a small pixel-art sprite.
 #
-# Pipeline: optional background knockout -> edge detection at full res ->
-# Lanczos downsample -> palette quantize -> composite edges as black pixels ->
+# Pipeline: background removal (rembg or corner flood-fill) ->
+# crop to opaque bbox -> optional pad-to-square -> contrast/saturation pre-pass ->
+# Sobel edges at full res -> aspect-preserving Lanczos downsample ->
+# palette quantize (fixed or source-sampled) -> composite edges as black pixels ->
 # optional integer upscale for preview.
 #
 # Usage: script/pixelize INPUT OUTPUT [options]
@@ -10,9 +12,10 @@
 import argparse
 import sys
 import urllib.request
+from io import BytesIO
 from pathlib import Path
 
-from PIL import Image, ImageFilter, ImageOps
+from PIL import Image, ImageChops, ImageEnhance, ImageFilter, ImageOps
 
 PALETTES = {
     "db16": [
@@ -30,6 +33,8 @@ PALETTES = {
     "grayscale": [(v, v, v) for v in range(0, 256, 17)][:16],
 }
 
+PALETTE_CHOICES = sorted(list(PALETTES.keys()) + ["sampled"])
+
 
 def load_image(source: str) -> Image.Image:
     if source.startswith(("http://", "https://")):
@@ -42,10 +47,31 @@ def load_image(source: str) -> Image.Image:
     return Image.open(source)
 
 
-def knockout_background(img: Image.Image, tolerance: int = 24) -> Image.Image:
-    # Flood-fills from the four corners with a near-color tolerance, sets
-    # matching pixels to transparent. Works well for catalog-style images on
-    # a roughly uniform (usually white) background. Not a full rembg.
+def rembg_background(img: Image.Image) -> Image.Image:
+    # Neural background removal via rembg's u2net model. The ~170MB model
+    # weights aren't checked in (see script/pixelize_models/README.md for why
+    # and where to get them). If the file exists at script/pixelize_models/,
+    # we point U2NET_HOME at it to skip the download. Otherwise rembg downloads
+    # to ~/.u2net/ on first use, hash-verified against its pinned MD5.
+    import os as _os
+    models_dir = Path(__file__).resolve().parent / "pixelize_models"
+    if (models_dir / "u2net.onnx").exists():
+        _os.environ["U2NET_HOME"] = str(models_dir)
+    try:
+        from rembg import remove
+    except ImportError:
+        sys.exit("error: --rembg requires `pip install rembg` (pulls ~170MB ONNX weights on first run if not vendored)")
+    rgba = img.convert("RGBA")
+    result = remove(rgba)
+    if isinstance(result, Image.Image):
+        return result.convert("RGBA")
+    return Image.open(BytesIO(result)).convert("RGBA")
+
+
+def knockout_background(img: Image.Image, tolerance: int = 32) -> Image.Image:
+    # Corner flood-fill with a near-color tolerance. Works for catalog-style
+    # images on a roughly uniform background. Cannot remove watermarks, shadows,
+    # or rescue cluttered photos — use --rembg for those.
     img = img.convert("RGBA")
     w, h = img.size
     pixels = img.load()
@@ -57,13 +83,11 @@ def knockout_background(img: Image.Image, tolerance: int = 24) -> Image.Image:
     stack = []
     for cx, cy in [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)]:
         stack.append((cx, cy, pixels[cx, cy]))
-
     while stack:
         x, y, target = stack.pop()
         if x < 0 or y < 0 or x >= w or y >= h or visited[x][y]:
             continue
-        cur = pixels[x, y]
-        if not close_enough(cur, target):
+        if not close_enough(pixels[x, y], target):
             continue
         visited[x][y] = True
         pixels[x, y] = (0, 0, 0, 0)
@@ -72,11 +96,57 @@ def knockout_background(img: Image.Image, tolerance: int = 24) -> Image.Image:
     return img
 
 
-def detect_edges(img: Image.Image, threshold: int) -> Image.Image:
-    # Returns a 1-bit mask (L mode, 0 or 255) where strong edges are 255.
+def crop_to_opaque_bbox(img: Image.Image) -> Image.Image:
+    bbox = img.getbbox()
+    return img.crop(bbox) if bbox else img
+
+
+def pad_to_square(img: Image.Image) -> Image.Image:
+    w, h = img.size
+    side = max(w, h)
+    canvas = Image.new("RGBA", (side, side), (0, 0, 0, 0))
+    canvas.paste(img, ((side - w) // 2, (side - h) // 2))
+    return canvas
+
+
+def prepass(img: Image.Image, contrast: float, saturation: float) -> Image.Image:
+    if contrast != 1.0:
+        img = ImageEnhance.Contrast(img).enhance(contrast)
+    if saturation != 1.0:
+        img = ImageEnhance.Color(img).enhance(saturation)
+    return img
+
+
+def sobel_edges(img: Image.Image, threshold: int) -> Image.Image:
+    # Returns an L-mode mask (0 or 255) where gradient magnitude >= threshold.
+    # Uses PIL's Kernel filter for a full Sobel operator; magnitude is
+    # approximated as max(|Gx|, |Gy|) which is cheap and visually indistinct
+    # from sqrt(Gx^2 + Gy^2) at our output sizes.
     gray = img.convert("L").filter(ImageFilter.GaussianBlur(radius=1))
-    edges = gray.filter(ImageFilter.FIND_EDGES)
-    return edges.point(lambda v: 255 if v >= threshold else 0)
+    gx_kernel = ImageFilter.Kernel((3, 3), [-1, 0, 1, -2, 0, 2, -1, 0, 1], scale=1, offset=128)
+    gy_kernel = ImageFilter.Kernel((3, 3), [-1, -2, -1, 0, 0, 0, 1, 2, 1], scale=1, offset=128)
+    gx = gray.filter(gx_kernel).point(lambda v: min(255, abs(v - 128) * 2))
+    gy = gray.filter(gy_kernel).point(lambda v: min(255, abs(v - 128) * 2))
+    mag = ImageChops.lighter(gx, gy)
+    return mag.point(lambda v: 255 if v >= threshold else 0)
+
+
+def sample_palette(img: Image.Image, n: int = 16) -> list:
+    # Pick n representative colors from the opaque pixels using median cut.
+    # Downsample first so this stays cheap on large inputs.
+    rgba = img.convert("RGBA")
+    thumb = rgba.copy()
+    thumb.thumbnail((256, 256), Image.Resampling.LANCZOS)
+    raw = thumb.tobytes()
+    opaque = [(raw[i], raw[i + 1], raw[i + 2]) for i in range(0, len(raw), 4) if raw[i + 3] > 0]
+    if not opaque:
+        return PALETTES["db16"]
+    side = max(1, int(len(opaque) ** 0.5))
+    sample = Image.new("RGB", (side, side))
+    sample.putdata(opaque[: side * side])
+    q = sample.quantize(colors=n, method=Image.Quantize.MEDIANCUT)
+    pal = q.getpalette()[: n * 3]
+    return [(pal[i], pal[i + 1], pal[i + 2]) for i in range(0, n * 3, 3)]
 
 
 def palette_image(colors) -> Image.Image:
@@ -91,27 +161,45 @@ def palette_image(colors) -> Image.Image:
 
 def quantize_to_palette(img: Image.Image, colors) -> Image.Image:
     rgb = img.convert("RGB")
-    pal = palette_image(colors)
-    quantized = rgb.quantize(palette=pal, dither=Image.Dither.NONE)
-    return quantized.convert("RGB")
+    return rgb.quantize(palette=palette_image(colors), dither=Image.Dither.NONE).convert("RGB")
+
+
+def compute_target(src_size, max_side, square):
+    w, h = src_size
+    if square:
+        return (max_side, max_side)
+    if w >= h:
+        return (max_side, max(1, round(max_side * h / w)))
+    return (max(1, round(max_side * w / h)), max_side)
 
 
 def pixelize(source: str, size: int, palette_name: str, edge_threshold: int,
-             do_bg_remove: bool, add_outline: bool) -> Image.Image:
+             bg_mode: str, contrast: float, saturation: float,
+             square: bool, add_outline: bool) -> Image.Image:
     src = load_image(source).convert("RGBA")
     src = ImageOps.exif_transpose(src)
 
-    if do_bg_remove and src.getextrema()[3][0] == 255:
+    if bg_mode == "rembg":
+        src = rembg_background(src)
+    elif bg_mode == "flood" and src.getextrema()[3][0] == 255:
         src = knockout_background(src)
 
+    src = crop_to_opaque_bbox(src)
+
+    if square:
+        src = pad_to_square(src)
+
+    src = prepass(src, contrast, saturation)
+
     has_alpha = src.getextrema()[3][0] < 255
+    edge_mask = sobel_edges(src, edge_threshold)
 
-    edge_mask = detect_edges(src, edge_threshold)
-    edge_small = edge_mask.resize((size, size), Image.Resampling.LANCZOS)
-    edge_small = edge_small.point(lambda v: 255 if v >= 96 else 0)
+    target = compute_target(src.size, size, square)
 
-    small = src.resize((size, size), Image.Resampling.LANCZOS)
+    edge_small = edge_mask.resize(target, Image.Resampling.LANCZOS)
+    edge_small = edge_small.point(lambda v: 255 if v >= 128 else 0)
 
+    small = src.resize(target, Image.Resampling.LANCZOS)
     alpha = small.split()[3] if has_alpha else None
     rgb_small = small.convert("RGB")
 
@@ -120,9 +208,12 @@ def pixelize(source: str, size: int, palette_name: str, edge_threshold: int,
         bg.paste(rgb_small, mask=alpha)
         rgb_small = bg
 
-    colors = PALETTES[palette_name]
-    quantized = quantize_to_palette(rgb_small, colors)
+    if palette_name == "sampled":
+        colors = sample_palette(src, n=16)
+    else:
+        colors = PALETTES[palette_name]
 
+    quantized = quantize_to_palette(rgb_small, colors)
     result = quantized.convert("RGBA")
 
     if add_outline and has_alpha:
@@ -141,8 +232,8 @@ def pixelize(source: str, size: int, palette_name: str, edge_threshold: int,
 
     pix = result.load()
     em = edge_small.load()
-    for y in range(size):
-        for x in range(size):
+    for y in range(result.size[1]):
+        for x in range(result.size[0]):
             if em[x, y] >= 128:
                 r, g, b, a = pix[x, y]
                 if a > 0:
@@ -160,34 +251,55 @@ def main():
     ap = argparse.ArgumentParser(description="Convert an image to pixel art.")
     ap.add_argument("input", help="Input path or URL")
     ap.add_argument("output", help="Output PNG path")
-    ap.add_argument("--size", type=int, default=32, help="Output size (default 32)")
-    ap.add_argument("--palette", choices=sorted(PALETTES.keys()), default="db16")
-    ap.add_argument("--edge-threshold", type=int, default=60,
-                    help="Edge detection threshold 0-255 (higher = fewer edges)")
-    ap.add_argument("--no-bg-remove", action="store_true",
-                    help="Skip corner-based background knockout")
+    ap.add_argument("--size", type=int, default=48,
+                    help="Longest-side output size in pixels (default 48)")
+    ap.add_argument("--palette", choices=PALETTE_CHOICES, default="sampled",
+                    help="Palette: db16, pico8, grayscale, or 'sampled' (median-cut from source; default)")
+    ap.add_argument("--edge-threshold", type=int, default=80,
+                    help="Sobel edge threshold 0-255 (higher = fewer edges, default 80)")
+    ap.add_argument("--contrast", type=float, default=1.3,
+                    help="Contrast multiplier applied before downsample (default 1.3, 1.0 = off)")
+    ap.add_argument("--saturation", type=float, default=1.5,
+                    help="Saturation multiplier applied before downsample (default 1.5, 1.0 = off)")
+    bg = ap.add_mutually_exclusive_group()
+    bg.add_argument("--rembg", action="store_true",
+                    help="Use rembg neural segmentation (best quality; needs `pip install rembg`)")
+    bg.add_argument("--no-bg-remove", action="store_true",
+                    help="Skip background removal entirely (use when input already has alpha)")
+    ap.add_argument("--square", action="store_true",
+                    help="Pad output to square instead of preserving rectangular aspect")
     ap.add_argument("--outline", action="store_true",
                     help="Add black 1px outline around opaque regions")
     ap.add_argument("--preview", type=int, default=0,
                     help="Also write an Nx-upscaled preview (e.g. 8)")
     args = ap.parse_args()
 
+    if args.rembg:
+        bg_mode = "rembg"
+    elif args.no_bg_remove:
+        bg_mode = "none"
+    else:
+        bg_mode = "flood"
+
     result = pixelize(
         source=args.input,
         size=args.size,
         palette_name=args.palette,
         edge_threshold=args.edge_threshold,
-        do_bg_remove=not args.no_bg_remove,
+        bg_mode=bg_mode,
+        contrast=args.contrast,
+        saturation=args.saturation,
+        square=args.square,
         add_outline=args.outline,
     )
     out = Path(args.output)
     out.parent.mkdir(parents=True, exist_ok=True)
     result.save(out)
-    print(f"wrote {out} ({args.size}x{args.size}, palette={args.palette})")
+    print(f"wrote {out} ({result.size[0]}x{result.size[1]}, palette={args.palette}, bg={bg_mode})")
 
     if args.preview > 0:
         big = result.resize(
-            (args.size * args.preview, args.size * args.preview),
+            (result.size[0] * args.preview, result.size[1] * args.preview),
             Image.Resampling.NEAREST,
         )
         preview_path = out.with_name(out.stem + f"_x{args.preview}" + out.suffix)

--- a/script/pixelize
+++ b/script/pixelize
@@ -31,6 +31,18 @@ PALETTES = {
         (0x29, 0xAD, 0xFF), (0x83, 0x76, 0x9C), (0xFF, 0x77, 0xA8), (0xFF, 0xCC, 0xAA),
     ],
     "grayscale": [(v, v, v) for v in range(0, 256, 17)][:16],
+    # TCP's art-direction palette (.claude/rules/art-direction.md §2).
+    # 6 cold + 6 warm = 12 canonical colors. Neither db16 nor pico8 covers
+    # TCP's desaturated mid-tones (Cable Gray, Dust Blue, Warning Amber),
+    # so use this palette to keep pixelize output on-model.
+    "tcp": [
+        # Cold (datacenter starting state)
+        (0x1A, 0x1E, 0x2E), (0x3B, 0x41, 0x57), (0x5B, 0x6B, 0x8A),
+        (0x4A, 0x9B, 0x9B), (0xC4, 0xA2, 0x4E), (0xD4, 0xDA, 0xE8),
+        # Warm (datacenter thriving state)
+        (0x2E, 0x20, 0x18), (0x6B, 0x52, 0x40), (0xC4, 0x95, 0x48),
+        (0xD4, 0x76, 0x3A), (0x5B, 0x8B, 0x4A), (0xF0, 0xE6, 0xD0),
+    ],
 }
 
 PALETTE_CHOICES = sorted(list(PALETTES.keys()) + ["sampled"])
@@ -60,7 +72,7 @@ def rembg_background(img: Image.Image) -> Image.Image:
     try:
         from rembg import remove
     except ImportError:
-        sys.exit("error: --rembg requires `pip install rembg` (pulls ~170MB ONNX weights on first run if not vendored)")
+        sys.exit("error: --rembg requires 'pip install rembg'. See script/pixelize_models/README.md")
     rgba = img.convert("RGBA")
     result = remove(rgba)
     if isinstance(result, Image.Image):

--- a/script/pixelize
+++ b/script/pixelize
@@ -53,9 +53,7 @@ def load_image(source: str) -> Image.Image:
         req = urllib.request.Request(source, headers={"User-Agent": "pixelize/1.0"})
         with urllib.request.urlopen(req, timeout=20) as r:
             data = r.read()
-        tmp = Path("/tmp/pixelize_input.bin")
-        tmp.write_bytes(data)
-        return Image.open(tmp)
+        return Image.open(BytesIO(data))
     return Image.open(source)
 
 
@@ -152,6 +150,9 @@ def sample_palette(img: Image.Image, n: int = 16) -> list:
     raw = thumb.tobytes()
     opaque = [(raw[i], raw[i + 1], raw[i + 2]) for i in range(0, len(raw), 4) if raw[i + 3] > 0]
     if not opaque:
+        # Fully-transparent input (bg removal erased everything, or a bug
+        # upstream). db16 is the safest retro-canonical fallback — widely
+        # recognized and has a broad-enough spread that "something" renders.
         return PALETTES["db16"]
     side = max(1, int(len(opaque) ** 0.5))
     sample = Image.new("RGB", (side, side))
@@ -176,7 +177,7 @@ def quantize_to_palette(img: Image.Image, colors) -> Image.Image:
     return rgb.quantize(palette=palette_image(colors), dither=Image.Dither.NONE).convert("RGB")
 
 
-def compute_target(src_size, max_side, square):
+def compute_target(src_size: tuple[int, int], max_side: int, square: bool) -> tuple[int, int]:
     w, h = src_size
     if square:
         return (max_side, max_side)

--- a/script/pixelize
+++ b/script/pixelize
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Converts an arbitrary image into a small pixel-art sprite.
+#
+# Pipeline: optional background knockout -> edge detection at full res ->
+# Lanczos downsample -> palette quantize -> composite edges as black pixels ->
+# optional integer upscale for preview.
+#
+# Usage: script/pixelize INPUT OUTPUT [options]
+
+import argparse
+import sys
+import urllib.request
+from pathlib import Path
+
+from PIL import Image, ImageFilter, ImageOps
+
+PALETTES = {
+    "db16": [
+        (0x14, 0x0C, 0x1C), (0x44, 0x24, 0x34), (0x30, 0x34, 0x6D), (0x4E, 0x4A, 0x4E),
+        (0x85, 0x4C, 0x30), (0x34, 0x65, 0x24), (0xD0, 0x46, 0x48), (0x75, 0x71, 0x61),
+        (0x59, 0x7D, 0xCE), (0xD2, 0x7D, 0x2C), (0x85, 0x95, 0xA1), (0x6D, 0xAA, 0x2C),
+        (0xD2, 0xAA, 0x99), (0x6D, 0xC2, 0xCA), (0xDA, 0xD4, 0x5E), (0xDE, 0xEE, 0xD6),
+    ],
+    "pico8": [
+        (0x00, 0x00, 0x00), (0x1D, 0x2B, 0x53), (0x7E, 0x25, 0x53), (0x00, 0x87, 0x51),
+        (0xAB, 0x52, 0x36), (0x5F, 0x57, 0x4F), (0xC2, 0xC3, 0xC7), (0xFF, 0xF1, 0xE8),
+        (0xFF, 0x00, 0x4D), (0xFF, 0xA3, 0x00), (0xFF, 0xEC, 0x27), (0x00, 0xE4, 0x36),
+        (0x29, 0xAD, 0xFF), (0x83, 0x76, 0x9C), (0xFF, 0x77, 0xA8), (0xFF, 0xCC, 0xAA),
+    ],
+    "grayscale": [(v, v, v) for v in range(0, 256, 17)][:16],
+}
+
+
+def load_image(source: str) -> Image.Image:
+    if source.startswith(("http://", "https://")):
+        req = urllib.request.Request(source, headers={"User-Agent": "pixelize/1.0"})
+        with urllib.request.urlopen(req, timeout=20) as r:
+            data = r.read()
+        tmp = Path("/tmp/pixelize_input.bin")
+        tmp.write_bytes(data)
+        return Image.open(tmp)
+    return Image.open(source)
+
+
+def knockout_background(img: Image.Image, tolerance: int = 24) -> Image.Image:
+    # Flood-fills from the four corners with a near-color tolerance, sets
+    # matching pixels to transparent. Works well for catalog-style images on
+    # a roughly uniform (usually white) background. Not a full rembg.
+    img = img.convert("RGBA")
+    w, h = img.size
+    pixels = img.load()
+    visited = [[False] * h for _ in range(w)]
+
+    def close_enough(a, b):
+        return all(abs(a[i] - b[i]) <= tolerance for i in range(3))
+
+    stack = []
+    for cx, cy in [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)]:
+        stack.append((cx, cy, pixels[cx, cy]))
+
+    while stack:
+        x, y, target = stack.pop()
+        if x < 0 or y < 0 or x >= w or y >= h or visited[x][y]:
+            continue
+        cur = pixels[x, y]
+        if not close_enough(cur, target):
+            continue
+        visited[x][y] = True
+        pixels[x, y] = (0, 0, 0, 0)
+        stack.extend([(x + 1, y, target), (x - 1, y, target),
+                      (x, y + 1, target), (x, y - 1, target)])
+    return img
+
+
+def detect_edges(img: Image.Image, threshold: int) -> Image.Image:
+    # Returns a 1-bit mask (L mode, 0 or 255) where strong edges are 255.
+    gray = img.convert("L").filter(ImageFilter.GaussianBlur(radius=1))
+    edges = gray.filter(ImageFilter.FIND_EDGES)
+    return edges.point(lambda v: 255 if v >= threshold else 0)
+
+
+def palette_image(colors) -> Image.Image:
+    pal = Image.new("P", (1, 1))
+    flat = []
+    for r, g, b in colors:
+        flat.extend([r, g, b])
+    flat.extend([0] * (256 * 3 - len(flat)))
+    pal.putpalette(flat)
+    return pal
+
+
+def quantize_to_palette(img: Image.Image, colors) -> Image.Image:
+    rgb = img.convert("RGB")
+    pal = palette_image(colors)
+    quantized = rgb.quantize(palette=pal, dither=Image.Dither.NONE)
+    return quantized.convert("RGB")
+
+
+def pixelize(source: str, size: int, palette_name: str, edge_threshold: int,
+             do_bg_remove: bool, add_outline: bool) -> Image.Image:
+    src = load_image(source).convert("RGBA")
+    src = ImageOps.exif_transpose(src)
+
+    if do_bg_remove and src.getextrema()[3][0] == 255:
+        src = knockout_background(src)
+
+    has_alpha = src.getextrema()[3][0] < 255
+
+    edge_mask = detect_edges(src, edge_threshold)
+    edge_small = edge_mask.resize((size, size), Image.Resampling.LANCZOS)
+    edge_small = edge_small.point(lambda v: 255 if v >= 96 else 0)
+
+    small = src.resize((size, size), Image.Resampling.LANCZOS)
+
+    alpha = small.split()[3] if has_alpha else None
+    rgb_small = small.convert("RGB")
+
+    if has_alpha:
+        bg = Image.new("RGB", rgb_small.size, (255, 255, 255))
+        bg.paste(rgb_small, mask=alpha)
+        rgb_small = bg
+
+    colors = PALETTES[palette_name]
+    quantized = quantize_to_palette(rgb_small, colors)
+
+    result = quantized.convert("RGBA")
+
+    if add_outline and has_alpha:
+        opaque = alpha.point(lambda v: 255 if v >= 128 else 0)
+        dilated = opaque.filter(ImageFilter.MaxFilter(3))
+        ring_mask = Image.new("L", result.size, 0)
+        d = dilated.load()
+        o = opaque.load()
+        rm = ring_mask.load()
+        for y in range(result.size[1]):
+            for x in range(result.size[0]):
+                if d[x, y] > 0 and o[x, y] == 0:
+                    rm[x, y] = 255
+        black = Image.new("RGBA", result.size, (0, 0, 0, 255))
+        result = Image.composite(black, result, ring_mask)
+
+    pix = result.load()
+    em = edge_small.load()
+    for y in range(size):
+        for x in range(size):
+            if em[x, y] >= 128:
+                r, g, b, a = pix[x, y]
+                if a > 0:
+                    pix[x, y] = (0, 0, 0, 255)
+
+    if has_alpha:
+        alpha_small = alpha.point(lambda v: 0 if v < 96 else 255)
+        r, g, b, _ = result.split()
+        result = Image.merge("RGBA", (r, g, b, alpha_small))
+
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Convert an image to pixel art.")
+    ap.add_argument("input", help="Input path or URL")
+    ap.add_argument("output", help="Output PNG path")
+    ap.add_argument("--size", type=int, default=32, help="Output size (default 32)")
+    ap.add_argument("--palette", choices=sorted(PALETTES.keys()), default="db16")
+    ap.add_argument("--edge-threshold", type=int, default=60,
+                    help="Edge detection threshold 0-255 (higher = fewer edges)")
+    ap.add_argument("--no-bg-remove", action="store_true",
+                    help="Skip corner-based background knockout")
+    ap.add_argument("--outline", action="store_true",
+                    help="Add black 1px outline around opaque regions")
+    ap.add_argument("--preview", type=int, default=0,
+                    help="Also write an Nx-upscaled preview (e.g. 8)")
+    args = ap.parse_args()
+
+    result = pixelize(
+        source=args.input,
+        size=args.size,
+        palette_name=args.palette,
+        edge_threshold=args.edge_threshold,
+        do_bg_remove=not args.no_bg_remove,
+        add_outline=args.outline,
+    )
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    result.save(out)
+    print(f"wrote {out} ({args.size}x{args.size}, palette={args.palette})")
+
+    if args.preview > 0:
+        big = result.resize(
+            (args.size * args.preview, args.size * args.preview),
+            Image.Resampling.NEAREST,
+        )
+        preview_path = out.with_name(out.stem + f"_x{args.preview}" + out.suffix)
+        big.save(preview_path)
+        print(f"wrote {preview_path} (preview {args.preview}x)")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/script/pixelize_models/.gitignore
+++ b/script/pixelize_models/.gitignore
@@ -1,0 +1,4 @@
+# Model weights are too large to ship (see README.md).
+# If you copy `~/.u2net/u2net.onnx` here for offline use, this keeps a
+# stray `git add` from dragging 176 MB into a commit.
+*.onnx

--- a/script/pixelize_models/README.md
+++ b/script/pixelize_models/README.md
@@ -1,0 +1,54 @@
+# Pixelize Models
+
+Drop-in location for `script/pixelize --rembg` to find the U²-Net background-removal model without hitting the network.
+
+## What goes here
+
+| File | Size | Purpose |
+|---|---|---|
+| `u2net.onnx` | ~176 MB | Weights for the [U²-Net](https://github.com/xuebinqin/U-2-Net) salient-object-detection model, used by `rembg` for `--rembg` background removal. |
+
+Not checked into git — too big for our LFS quota (GitHub free tier is 1 GB storage + 1 GB bandwidth/month, and a 176 MB file eats 17 % of that per fresh clone).
+
+## How to get the file
+
+**Option A — let rembg download it for you (easiest).**
+
+The first time you run `script/pixelize --rembg ...` with `rembg` installed, it fetches `u2net.onnx` into `~/.u2net/` automatically and verifies the MD5. No action needed from you.
+
+If you'd like it here instead of `~/.u2net/` (so it's discoverable alongside the tool that uses it), copy it after the first run:
+
+```sh
+cp ~/.u2net/u2net.onnx script/pixelize_models/u2net.onnx
+```
+
+The script checks this directory first and sets `U2NET_HOME` to skip the download on subsequent runs.
+
+**Option B — manual download + hash check.**
+
+```sh
+curl -L -o script/pixelize_models/u2net.onnx \
+  https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net.onnx
+echo "60024c5c889badc19c04ad937298a77b  script/pixelize_models/u2net.onnx" | md5sum -c
+```
+
+Expected MD5: `60024c5c889badc19c04ad937298a77b`.
+
+## Why the URL says `v0.0.0`
+
+That tripped us up too. It's a [rembg](https://github.com/danielgatis/rembg) convention, not a pre-release or a mistake — rembg uses a single pinned GitHub Release tag (`v0.0.0`) as a stable CDN for **all 14 of its model weights** (u2net, u2netp, silueta, birefnet_*, dis_*, bria_rmbg, etc.). Every model's download URL points at the same `v0.0.0` release. Unconventional, but deliberate and consistent. You can grep any installed rembg to confirm:
+
+```sh
+grep -r "releases/download/v0.0.0" <rembg-install-path>/sessions/
+```
+
+## Trust chain
+
+- **rembg package** — 22.6 k stars on GitHub, MIT licensed, maintained by Daniel Gatis. PyPI listing matches the GitHub repo owner.
+- **rembg pins the model hash in its source.** `rembg/sessions/u2net.py` declares `md5:60024c5c889badc19c04ad937298a77b`. When the download happens, `pooch` verifies the hash before handing the file to rembg — tampered downloads are rejected automatically (unless `MODEL_CHECKSUM_DISABLED` is set, which we never do).
+- **Underlying architecture** — U²-Net is peer-reviewed academic work: Qin et al., *Pattern Recognition* (2020), 2022 Best Paper Award. 9.7 k stars on `xuebinqin/U-2-Net`. Not a random hobbyist model.
+- **Single-maintainer caveat** — if Daniel's GitHub account is ever compromised, a new rembg release could ship a different hash pointing at a different file. Defense in depth: pin `rembg==<exact-version>` in any setup docs so the hash is pinned transitively.
+
+## If the file is missing
+
+`script/pixelize --rembg` will fall through to letting rembg download it on demand. No error unless `rembg` itself isn't installed.

--- a/script/pixelize_models/README.md
+++ b/script/pixelize_models/README.md
@@ -2,6 +2,18 @@
 
 Drop-in location for `script/pixelize --rembg` to find the U²-Net background-removal model without hitting the network.
 
+## Setup
+
+The `--rembg` flag needs the `rembg` package (plus its ONNX runtime). Install in a venv so you don't pollute your global environment:
+
+```sh
+python3 -m venv .venv-pixelize
+.venv-pixelize/bin/pip install rembg onnxruntime
+.venv-pixelize/bin/python script/pixelize input.jpg out.png --rembg --preview 8
+```
+
+The pure-PIL path (no `--rembg`) only needs Pillow, which Python ships or is a one-liner `pip install Pillow`.
+
 ## What goes here
 
 | File | Size | Purpose |


### PR DESCRIPTION
## Summary

A small Python/PIL CLI (`script/pixelize`) that turns an arbitrary photo or web image into a pixel-art sprite. Two-commit PR: the first commit introduces the tool, the second folds in improvements after iterating on a real input (antique gramophone).

- **Aspect-preserving** by default (cropping to opaque bbox, preserving source ratio). `--square` pads to square if you need tile-aligned output.
- **Source-sampled palette** (default) picks 16 representative colors via median cut on the opaque pixels; classic fixed palettes still available via `--palette db16|pico8|grayscale`.
- **Pre-pass** applies `--contrast 1.3 --saturation 1.5` before downsampling so quantized colors don't go muddy.
- **Sobel edge detection** via PIL's `Kernel` filter (no numpy dep) replaces the toy `FIND_EDGES`; `--edge-threshold` now actually controls edge density.
- **`--rembg`** uses the U²-Net neural segmentation model for clean background removal (kills watermarks and cluttered backgrounds that corner flood-fill can't touch). Graceful error if `rembg` isn't installed; flood-fill remains the default so the tool works out of the box.
- **Default `--size 48`** for complex subjects (was 32).

### Why `u2net.onnx` is not vendored

`rembg` stores its model weights (~176 MB) in a GitHub Release on its own repo. I considered vendoring them via git LFS but GitHub's free LFS quota is 1 GB storage + 1 GB bandwidth/month — one fresh clone eats 17% of that. `script/pixelize_models/README.md` explains where the file comes from, why `rembg`'s download URL has a `v0.0.0` tag (it's a convention across all 14 of rembg's models, not a mistake), and the trust chain. `rembg` auto-downloads on first `--rembg` use and verifies against a pinned MD5; the script also checks `script/pixelize_models/` first via `U2NET_HOME` so contributors can opt into a local copy.

## Usage

```sh
script/pixelize input.jpg output.png --preview 8
script/pixelize input.jpg output.png --rembg --outline --size 32 --preview 8
```

## Test plan

- [ ] Pure-PIL path: `script/pixelize tests/fixtures/some.jpg /tmp/out.png --preview 8` produces a non-empty output and a `_x8.png` preview.
- [ ] Legacy palette backward-compat: `--palette db16` matches prior behavior minus the aspect fix.
- [ ] `--no-bg-remove` skips flood-fill cleanly on an already-alpha input.
- [ ] `--rembg` without `rembg` installed exits with the install-hint error (non-zero exit code, clear message).
- [ ] With `rembg` installed, `--rembg` uses `script/pixelize_models/u2net.onnx` if present, otherwise falls through to `~/.u2net/`.
- [ ] `--square` pads to an NxN sprite for tile-aligned workflows.