### PR TITLE
ci: make PR review actually work, and run as Bramble

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,27 +1,25 @@
-name: Claude Code Review
+name: Bramble — PR Review
+
+# Why this exists: automated PR reviewer using TCP's game-programmer agent
+# (Bramble, defined in .claude/agents/game-programmer.md). Runs on the
+# initial PR events only — not on every push — to stay inside the Claude
+# subscription quota and avoid review spam. Trigger a fresh review by
+# reopening or moving the PR from draft to ready.
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, reopened, ready_for_review]
+
+concurrency:
+  group: bramble-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+  bramble:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write   # required so Bramble can post the review
       issues: read
       id-token: write
 
@@ -31,14 +29,23 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
+      - name: Run Bramble review
+        id: bramble
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            You are Bramble, TCP's lead programmer. Read `.claude/agents/game-programmer.md` for your persona and review standards, and TCP's code philosophy from `.claude/rules/` (the always-loaded and path-loaded rules that apply to the changed files).
 
+            Review pull request #${{ github.event.pull_request.number }}. Pull the diff with `gh pr diff ${{ github.event.pull_request.number }}` and, for context, `gh pr view ${{ github.event.pull_request.number }}`. Evaluate against TCP's rules: capabilities (not species), signal patterns, integer values, null-freedom, test philosophy. For non-GDScript files (Python tools, docs, CI, config), apply general code-quality lenses only — skip the GDScript-specific rules.
+
+            Structure the review exactly:
+
+            **Blockers** — must fix before merge (or "None")
+            **Should-fix** — non-blocking but real concerns (or "None")
+            **Nitpicks** — taste, mention once (or "None")
+            **Verdict** — mergeable as-is, or needs changes?
+
+            Post exactly one review via `gh pr review ${{ github.event.pull_request.number }} --comment --body "<markdown>"`. Sign the body on the last line: "— Bramble". Do not approve or request changes — comment only.
+
+            Do not push commits. Do not edit files. Review only.


### PR DESCRIPTION
## Why

The current `claude-code-review.yml` has been running for weeks without leaving a single comment on any PR. Two root causes:

1. **Missing permissions.** Workflow had `pull-requests: read`. The action ran Claude fine but couldn't post anything back. Runs completed "successfully" with zero output.
2. **Generic plugin prompt.** It invoked `/code-review:code-review` from Anthropic's marketplace — not wrong, just generic. TCP already has Bramble (`.claude/agents/game-programmer.md`) tuned to our code philosophy. Better to use her.

## What this changes

- `pull-requests: write` — so the review actually posts.
- Replace the generic plugin with an inline prompt that loads Bramble + TCP's `.claude/rules/` and produces a structured **Blockers / Should-fix / Nitpicks / Verdict** review signed "— Bramble".
- Trim trigger from `[opened, synchronize, ready_for_review, reopened]` → `[opened, reopened, ready_for_review]`. `synchronize` fires on every push to a PR branch — that was burning Claude subscription quota with no added signal. Re-trigger a review by reopening a PR or flipping draft→ready.
- Add a `concurrency:` group so newer pushes cancel stale pending reviews.

The `claude-code-action` restores `.claude/` from `origin/main` (not PR head) for security, so PRs still can't mutate Bramble's own persona to influence their own review.

## Test plan

- [ ] Merge, then open or reopen any PR. Verify Bramble posts a review within ~2 min signed "— Bramble".
- [ ] Confirm the review follows the four-section structure.
- [ ] Confirm subsequent pushes to that PR do NOT trigger additional reviews.
- [ ] Close + reopen the PR — should trigger a fresh review.

## Notes

If Bramble's review is too chatty or too sparse, tune the prompt in `.github/workflows/claude-code-review.yml`. The other workflow (`.github/workflows/claude.yml`) that handles `@claude` mentions in comments is untouched.