### PR TITLE
ci: actually let Bramble post — native comment + inline MCP tool

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,18 +34,31 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Why this exact allowlist: the action's native review-posting surface
+          # is `gh pr comment` (top-level summary) plus the
+          # `mcp__github_inline_comment__create_inline_comment` MCP tool
+          # (line-specific). Claude has no built-in "post PR review" ability —
+          # it must shell out or use an MCP tool, and Bash is off by default.
+          # This is the pattern from anthropics/claude-code-action docs.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
-            You are Bramble, TCP's lead programmer. Read `.claude/agents/game-programmer.md` for your persona and review standards, and TCP's code philosophy from `.claude/rules/` (the always-loaded and path-loaded rules that apply to the changed files).
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review pull request #${{ github.event.pull_request.number }}. Pull the diff with `gh pr diff ${{ github.event.pull_request.number }}` and, for context, `gh pr view ${{ github.event.pull_request.number }}`. Evaluate against TCP's rules: capabilities (not species), signal patterns, integer values, null-freedom, test philosophy. For non-GDScript files (Python tools, docs, CI, config), apply general code-quality lenses only — skip the GDScript-specific rules.
+            You are Bramble, TCP's lead programmer. Read `.claude/agents/game-programmer.md` for your persona and review standards, and TCP's code philosophy from `.claude/rules/` (the always-loaded and path-loaded rules that apply to the changed files). The PR branch is already checked out in the current working directory; you can also run `gh pr diff` and `gh pr view` for context.
 
-            Structure the review exactly:
+            Evaluate against TCP's rules: capabilities (not species), signal patterns, integer values, null-freedom, test philosophy. For non-GDScript files (Python tools, docs, CI, config), apply general code-quality lenses only — skip the GDScript-specific rules.
+
+            Post ONE summary comment via `gh pr comment ${{ github.event.pull_request.number }} --body "<markdown>"` with this exact structure:
 
             **Blockers** — must fix before merge (or "None")
             **Should-fix** — non-blocking but real concerns (or "None")
             **Nitpicks** — taste, mention once (or "None")
             **Verdict** — mergeable as-is, or needs changes?
 
-            Post exactly one review via `gh pr review ${{ github.event.pull_request.number }} --comment --body "<markdown>"`. Sign the body on the last line: "— Bramble". Do not approve or request changes — comment only.
+            Sign the last line: "— Bramble".
 
-            Do not push commits. Do not edit files. Review only.
+            For specific line-level feedback, use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) — do not repeat inline findings in the summary comment.
+
+            Only post GitHub comments — do not submit review text as SDK messages or as commits. Do not push commits. Do not edit files. Review only.


### PR DESCRIPTION
## Why

PR #16 fixed permissions. The first real Bramble run (on reopened #15) succeeded — 27 turns, \$1.96, no errors — but posted nothing. Log shows `No buffered inline comments` and zero output on the PR.

Two bugs in the prompt I didn't know about:

1. **`gh pr review --comment` is the wrong surface.** The action wants `gh pr comment` (top-level) and `mcp__github_inline_comment__create_inline_comment` (line-specific). That's the official pattern from [claude-code-action docs/solutions.md](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md).
2. **Claude Code has no bash by default in this action.** So even if `gh pr review` had been the right command, Claude couldn't execute it — Bash is gated behind `claude_args: --allowedTools`. Without the allowlist, Claude silently wrote the review text into the Actions log (which nobody sees) and considered the task done.

## Changes

- `claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"` — minimal, scoped allowlist.
- Summary review via `gh pr comment` (was `gh pr review --comment`).
- Line-level findings via the inline-comment MCP tool; summary stays short.
- Explicit "Only post GitHub comments — do not submit review text as SDK messages." This prevents the silent-log-dump failure mode from the first run.

## Test plan

- [ ] Merge this PR. The self-healing "workflow file must match default branch" check will fail on this PR itself (known, per #16).
- [ ] Open or reopen any PR. Bramble should post a summary comment within ~2 min, signed "— Bramble".
- [ ] Confirm the summary follows Blockers / Should-fix / Nitpicks / Verdict.
- [ ] If Bramble has line-specific findings, check that they appear as inline review comments on specific lines of the diff.